### PR TITLE
Increased points to 3 chars and corrected welcome message typo

### DIFF
--- a/embed.lua
+++ b/embed.lua
@@ -154,9 +154,9 @@ function CustomAchieverFrame_OnLoad(self)
 
 	local pointsFontstring = CustomAchieverFrame:CreateFontString("PointsFontstring", "ARTWORK", "GameFontNormal")
 	pointsFontstring:SetText(L["MENUCUSTAC_POINTS"])
-	pointsFontstring:SetPoint("TOPRIGHT", -70, -197)
+	pointsFontstring:SetPoint("TOPRIGHT", -80, -197)
 	CustomAchieverFrame.PointsEditBox:SetPoint("TOPRIGHT", -30 , -195)
-	CustomAchieverFrame.PointsEditBox:SetSize(20, 16)
+	CustomAchieverFrame.PointsEditBox:SetSize(30, 16)
 	CustomAchieverFrame.PointsEditBox:HighlightText()
 	CustomAchieverFrame.PointsEditBox.type = "achievementPoints"
 

--- a/embed.xml
+++ b/embed.xml
@@ -232,7 +232,7 @@
 					<OnEscapePressed function="HideParentPanel"/>
 				</Scripts>
 			</EditBox>
-			<EditBox parentKey="PointsEditBox" inherits="InputBoxTemplate" letters="2" numeric="true">
+			<EditBox parentKey="PointsEditBox" inherits="InputBoxTemplate" letters="3" numeric="true">
 				<Scripts>
 					<OnTextChanged function="CustomAchieverFrameEditBox_OnTextChanged"/>
 					<OnEscapePressed function="HideParentPanel"/>

--- a/localization/localization.lua
+++ b/localization/localization.lua
@@ -2,7 +2,7 @@ local L = LibStub("AceLocale-3.0"):NewLocale("CustomAchiever", "enUS", true)
 
 if L then
 
-L["CUSTOMACHIEVER_WELCOME"] = "Type /cusac to show Custom Achiever."
+L["CUSTOMACHIEVER_WELCOME"] = "Type /custac to show Custom Achiever."
 
 L["SPACE_BEFORE_DOT"] = ""
 


### PR DESCRIPTION
- Corrected a minor typo in welcome message which showed the wrong command (`/cusac` rather than `/custac`)
- Modified points field to allow 3 characters so that achievements with 100 achievement points (e.g. [A World Awoken](https://www.wowhead.com/achievement=19458/a-world-awoken)) can be created
    - Also increased field size and moved text to maintain same blank space. Screenshot below showing new look with 3-digit number
![image](https://github.com/user-attachments/assets/7e231bd6-faae-4946-aabf-c6ef8f49fc58)

Apologies if I've missed anything important, I have fairly minimal experience with lua and zero experience with WoW addons